### PR TITLE
chore: swap state wording changes

### DIFF
--- a/BTCPayServer.Plugins.Boltz/Views/Boltz/SetupStandalone.cshtml
+++ b/BTCPayServer.Plugins.Boltz/Views/Boltz/SetupStandalone.cshtml
@@ -5,7 +5,7 @@
 @using Microsoft.AspNetCore.Mvc.TagHelpers
 @{
     Layout = "_LayoutSetup";
-    ViewData["Title"] = "How does it work";
+    ViewData["Title"] = "How does it work?";
 
     var storeId = Context.GetImplicitStoreId();
 }

--- a/BTCPayServer.Plugins.Boltz/Views/Boltz/SetupStandalone.cshtml
+++ b/BTCPayServer.Plugins.Boltz/Views/Boltz/SetupStandalone.cshtml
@@ -15,12 +15,12 @@
 </p>
 
 <div>
-    <h4>Current Pair Info</h4>
+    <h4>Fees and Amounts</h4>
     <partial name="Boltz/_Fees" model="FeesModel.Standalone"/>
 </div>
 
 <p class="text-secondary my-3">
-    Note: Boltz swaps are non-custodial, but the Liquid Network is run a by a federation and requires trusting the entities in the federation to guard L-BTC, the Liquid representation of Bitcoin. Learn more about the Liquid network here.
+    Note: Boltz swaps are non-custodial, but the Liquid Network is run a by a federation and requires trusting the entities in the federation to guard L-BTC, the Liquid representation of Bitcoin. Learn more about the Liquid network <a href="https://liquid.net/" target="_blank">here</a>.
 </p>
 
 <a asp-controller="Boltz" asp-action="SetupWallet" asp-route-storeId="@storeId" asp-route-flow="@WalletSetupFlow.Standalone" class="btn btn-success">

--- a/BTCPayServer.Plugins.Boltz/Views/Boltz/_SwapInfoPartial.cshtml
+++ b/BTCPayServer.Plugins.Boltz/Views/Boltz/_SwapInfoPartial.cshtml
@@ -179,7 +179,7 @@
 
         if (swap.Status == "transaction.server.mempool")
         {
-            instruction = "Waiting for confirmation of server lockup";
+            instruction = "Waiting for confirmation of Boltz lockup transaction";
             transaction = swap.ToData.LockupTransactionId;
             transactionCurrency = swap.Pair.From;
         }


### PR DESCRIPTION
Could you also double check https://github.com/BoltzExchange/btcpayserver-boltz/blob/04a736b790fcd2b16369aea8a0b37f794b015a64/BTCPayServer.Plugins.Boltz/Views/Boltz/Components/SwapInfo/Default.cshtml#L121 - doesn't look like the correct message @jackstar12 